### PR TITLE
Add run_worker.sh stub

### DIFF
--- a/files/recipe-worker.yaml
+++ b/files/recipe-worker.yaml
@@ -1,8 +1,13 @@
 ---
-- name: This is a recipe for how to cook with hardly
+- name: Prepare worker
   hosts: all
   vars:
     home_path: "{{ lookup('env', 'HOME') }}"
     packit_service_path: /src
   tasks:
     - import_tasks: tasks/common.yaml
+    - name: Copy run_worker.sh
+      copy:
+        src: run_worker.sh
+        dest: /usr/bin/run_worker.sh
+        mode: 0777

--- a/files/run_worker.sh
+++ b/files/run_worker.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/bash
+
+source /src/files/setup_env_in_openshift.sh
+
+sleep 10000

--- a/files/setup_env_in_openshift.sh
+++ b/files/setup_env_in_openshift.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/bash
+
+# uncomment for debugging
+# set -x
+
+export PACKIT_HOME=/home/packit
+# Generate passwd file based on current uid, needed for fedpkg
+grep -v ^packit /etc/passwd > ${PACKIT_HOME}/passwd
+printf "packit:x:$(id -u):0:Packit Service:/home/packit:/bin/bash\n" >> ${PACKIT_HOME}/passwd
+export LD_PRELOAD=libnss_wrapper.so
+export NSS_WRAPPER_PASSWD=${HOME}/passwd
+export NSS_WRAPPER_GROUP=/etc/group


### PR DESCRIPTION
See [CMD in Dockerfile.worker](https://github.com/packit/hardly/blob/main/files/docker/Dockerfile.worker#L36)

The setup_env_in_openshift.sh is needed for arbitrary user IDs in Openshift to work.