### PR TITLE
Decide which MRs to handle based on the service configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 BASE_IMAGE ?= quay.io/packit/packit-worker
 HARDLY_IMAGE ?= quay.io/packit/hardly:dev
 TEST_IMAGE ?= hardly-tests
-TEST_TARGET ?= ./tests/integration/
+TEST_TARGET ?= ./tests/
 CONTAINER_ENGINE ?= $(shell command -v podman 2> /dev/null || echo docker)
 ANSIBLE_PYTHON ?= /usr/bin/python3
 AP ?= ansible-playbook -vv -c local -i localhost, -e ansible_python_interpreter=$(ANSIBLE_PYTHON)

--- a/tests/integration/test_dist_git_mr.py
+++ b/tests/integration/test_dist_git_mr.py
@@ -66,6 +66,7 @@ def test_dist_git_mr(mr_event):
 
     config = ServiceConfig()
     config.command_handler_work_dir = SANDCASTLE_WORK_DIR
+    config.gitlab_mr_targets_handled = None
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(config)
     flexmock(Pushgateway).should_receive("push").once().and_return()
     flexmock(PackitAPI).should_receive("sync_release").with_args(

--- a/tests/unit/test_distgit.py
+++ b/tests/unit/test_distgit.py
@@ -1,0 +1,71 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+from flexmock import flexmock
+from hardly.handlers.distgit import DistGitMRHandler
+
+
+@pytest.mark.parametrize(
+    "targets_handled, target_repo, target_branch, handled",
+    [
+        pytest.param(
+            None, "redhat/centos-stream/src/make", "c9s", True, id="no config"
+        ),
+        pytest.param(
+            [flexmock(repo=None, branch="c9s")],
+            "redhat/centos-stream/src/make",
+            "c8",
+            False,
+            id="only branch config, mismatch",
+        ),
+        pytest.param(
+            [flexmock(repo="redhat/centos-stream/src/.+", branch="c9s")],
+            "redhat/centos-stream/src/make",
+            "c9s",
+            True,
+            id="branch and repo config",
+        ),
+        pytest.param(
+            [
+                flexmock(repo="redhat/centos-stream/src/.+", branch="c9s"),
+                flexmock(repo="packit-service/src/.+", branch=None),
+            ],
+            "packit-service/src/make",
+            "rawhide",
+            True,
+            id="multi config, match",
+        ),
+        pytest.param(
+            [
+                flexmock(repo="redhat/centos-stream/src/.+", branch="c9s"),
+                flexmock(repo="packit-service/src/.+", branch=None),
+            ],
+            "packit-service/rpms/make",
+            "rawhide",
+            False,
+            id="multi config, repo mismatch",
+        ),
+        pytest.param(
+            [
+                flexmock(repo="packit-service/src/.+", branch="(c9s|rawhide)"),
+                flexmock(repo="redhat/centos-stream/src/.+", branch="c9s"),
+            ],
+            "packit-service/src/make",
+            "test",
+            False,
+            id="multi config, branch mismatch",
+        ),
+    ],
+)
+def test_handle_target(targets_handled, target_repo, target_branch, handled):
+    """Check if target repositories and branches are correctly told to be handled or not,
+    according to the service configuration."""
+    service_config = flexmock(gitlab_mr_targets_handled=targets_handled)
+    mock_mr_handler = flexmock(
+        service_config=service_config,
+        target_repo=target_repo,
+        target_repo_branch=target_branch,
+    )
+    assert DistGitMRHandler.handle_target(mock_mr_handler) == handled


### PR DESCRIPTION
Check the service configuration (`gitlab_mr_targets_handled`) to tell if
an MR opened to be merged in a target repo and branch should be handled
or not.

If there is no such configuration, handle MRs for all target repos and
branches.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>

Merge after packit/packit-service#1259

---

N/A