### PR TITLE
Update comments to apply to Fedora as well

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,11 +20,15 @@ repos:
     hooks:
       - id: check-added-large-files
       - id: check-ast
+      - id: check-builtin-literals
+      - id: check-docstring-first
+      - id: check-executables-have-shebangs
       - id: check-merge-conflict
+      - id: check-symlinks
       - id: check-yaml
-        exclude: zuul.d
       - id: detect-private-key
       - id: end-of-file-fixer
+      - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
@@ -40,7 +44,7 @@ repos:
         args: [--no-strict-optional, --ignore-missing-imports]
         additional_dependencies: [types-pkg_resources]
   - repo: https://github.com/packit/pre-commit-hooks
-    rev: 1da916777f5cc26ecf221b15e58ca51891d26d94
+    rev: 3bf9afc5ede12a4ee26e9451f306edf255749396
     hooks:
       - id: check-rebase
         args:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: redis
     ports:
       - 6379:6379
-    user: "123123"
+    user: "1024"
 
   postgres:
     container_name: postgres
@@ -47,14 +47,10 @@ services:
       - ../ogr/ogr:/usr/local/lib/python3.9/site-packages/ogr:ro,z
       - ../packit/packit:/usr/local/lib/python3.9/site-packages/packit:ro,z
       - ../packit-service/packit_service:/usr/local/lib/python3.9/site-packages/packit_service:ro,z
-      # worker should not require packit-service.yaml
       - ./secrets/stream/dev/packit-service.yaml:/home/packit/.config/packit-service.yaml:ro,z
-      - ./secrets/stream/dev/copr:/home/packit/.config/copr:ro,z
-      - ./secrets/stream/dev/ssh_config:/packit-ssh/config:ro,z
       - ./secrets/stream/dev/id_rsa.pub:/packit-ssh/id_rsa.pub:ro,z
       - ./secrets/stream/dev/id_rsa:/packit-ssh/id_rsa:ro,z
-      - ./secrets/stream/dev/private-key.pem:/secrets/private-key.pem:ro,z
-    user: "123123"
+    user: "1024"
 
   service:
     container_name: service
@@ -80,7 +76,6 @@ services:
       # There's no secrets/ by default. You have to create (or symlink to other dir) it yourself.
       # Make sure to set `command_handler: local` since there is no kube in d-c
       - ./secrets/stream/dev/packit-service.yaml:/home/packit/.config/packit-service.yaml:ro,z
-      - ./secrets/stream/dev/private-key.pem:/secrets/private-key.pem:ro,z
       - ./secrets/stream/dev/fullchain.pem:/secrets/fullchain.pem:ro,z
       - ./secrets/stream/dev/privkey.pem:/secrets/privkey.pem:ro,z
-    user: "123123"
+    user: "1024"

--- a/hardly/handlers/distgit.py
+++ b/hardly/handlers/distgit.py
@@ -83,7 +83,9 @@ class DistGitMRHandler(JobHandler):
         )
         dg_mr_info = f"""###### Info for package maintainer
 This MR has been automatically created from
-[this source-git MR]({self.mr_url}).
+[this source-git MR]({self.mr_url})."""
+        if getenv("PROJECT") and getenv("PROJECT").startswith("stream"):
+            dg_mr_info += """
 Please review the contribution and once you are comfortable with the content,
 you should trigger a CI pipeline run via `Pipelines → Run pipeline`."""
         dg_mr = self.api.sync_release(
@@ -99,8 +101,8 @@ you should trigger a CI pipeline run via `Pipelines → Run pipeline`."""
         if dg_mr:
             comment = f"""[Dist-git MR #{dg_mr.id}]({dg_mr.url})
 has been created for sake of triggering the downstream checks.
-It ensures that your contribution is valid and can be incorporated in CentOS Stream
-as dist-git is still the authoritative source for the distribution.
+It ensures that your contribution is valid and can be incorporated in
+dist-git as it is still the authoritative source for the distribution.
 We want to run checks there only so they don't need to be reimplemented in source-git as well."""
             self.project.get_pr(int(self.mr_identifier)).comment(comment)
 

--- a/tests/integration/test_dist_git_mr.py
+++ b/tests/integration/test_dist_git_mr.py
@@ -80,9 +80,7 @@ of the expected packet header.
 ---
 ###### Info for package maintainer
 This MR has been automatically created from
-[this source-git MR](https://gitlab.com/packit-service/src/open-vm-tools/-/merge_requests/5).
-Please review the contribution and once you are comfortable with the content,
-you should trigger a CI pipeline run via `Pipelines → Run pipeline`.""",
+[this source-git MR](https://gitlab.com/packit-service/src/open-vm-tools/-/merge_requests/5).""",
         sync_default_files=False,
         local_pr_branch_suffix="src-5",
     ).once()


### PR DESCRIPTION
Remove notes about CentOS Stream and pipelines in comments that the bot adds to MR/PRs.

Otherwise, it's mostly just docs and docker-compose/pre-commit update.