### PR TITLE
Add Handler for syncing from Pagure dist-git PR

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,11 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.31.1
     hooks:
       - id: pyupgrade
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.5.1
+    rev: v2.6.0
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -38,7 +38,7 @@ repos:
           - --max-line-length=100
           - --per-file-ignores=files/packit.wsgi:F401,E402
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v0.941
     hooks:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,3 +79,20 @@ services:
       - ./secrets/${SERVICE}/dev/fullchain.pem:/secrets/fullchain.pem:ro,z
       - ./secrets/${SERVICE}/dev/privkey.pem:/secrets/privkey.pem:ro,z
     user: "1024"
+
+  fedora-messaging:
+    container_name: fedora-messaging
+    # If you want to test your changes in packit-service-fedmsg,
+    # run 'make build' in cloned packit-service-fedmsg
+    # and change this to :dev
+    image: quay.io/packit/packit-service-fedmsg:stg
+    depends_on:
+      - redis
+    environment:
+      DEPLOYMENT: dev
+      FEDORA_MESSAGING_CONF: /home/packit/.config/fedora.toml
+      REDIS_SERVICE_HOST: redis
+    volumes:
+      # get it from secrets
+      - ./secrets/${SERVICE}/dev/fedora.toml:/home/packit/.config/fedora.toml:ro,Z
+    user: "1024"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,9 +46,9 @@ services:
       PUSHGATEWAY_ADDRESS: ""
     volumes:
       - ./hardly:/src/hardly:ro,z
-      - ../ogr/ogr:/usr/local/lib/python3.9/site-packages/ogr:ro,z
-      - ../packit/packit:/usr/local/lib/python3.9/site-packages/packit:ro,z
-      - ../packit-service/packit_service:/usr/local/lib/python3.9/site-packages/packit_service:ro,z
+      - ../ogr/ogr:/usr/local/lib/python3.10/site-packages/ogr:ro,z
+      - ../packit/packit:/usr/local/lib/python3.10/site-packages/packit:ro,z
+      - ../packit-service/packit_service:/usr/local/lib/python3.10/site-packages/packit_service:ro,z
       - ./secrets/${SERVICE}/dev/packit-service.yaml:/home/packit/.config/packit-service.yaml:ro,z
       - ./secrets/${SERVICE}/dev/id_rsa.pub:/packit-ssh/id_rsa.pub:ro,z
       - ./secrets/${SERVICE}/dev/id_rsa:/packit-ssh/id_rsa:ro,z
@@ -71,9 +71,9 @@ services:
       POSTGRESQL_HOST: postgres
       POSTGRESQL_DATABASE: packit
     volumes:
-      - ../ogr/ogr:/usr/local/lib/python3.9/site-packages/ogr:ro,z
-      - ../packit/packit:/usr/local/lib/python3.9/site-packages/packit:ro,z
-      - ../packit-service/packit_service:/usr/local/lib/python3.9/site-packages/packit_service:ro,z
+      - ../ogr/ogr:/usr/local/lib/python3.10/site-packages/ogr:ro,z
+      - ../packit/packit:/usr/local/lib/python3.10/site-packages/packit:ro,z
+      - ../packit-service/packit_service:/usr/local/lib/python3.10/site-packages/packit_service:ro,z
       - ../packit-service/alembic:/src/alembic:ro,z
       - ./secrets/${SERVICE}/dev/packit-service.yaml:/home/packit/.config/packit-service.yaml:ro,z
       - ./secrets/${SERVICE}/dev/fullchain.pem:/secrets/fullchain.pem:ro,z

--- a/hardly/handlers/__init__.py
+++ b/hardly/handlers/__init__.py
@@ -1,8 +1,14 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-from hardly.handlers.distgit import DistGitMRHandler
+from hardly.handlers.distgit import (
+    DistGitMRHandler,
+    SyncFromGitlabMRHandler,
+    SyncFromPagurePRHandler,
+)
 
 __all__ = [
     DistGitMRHandler.__name__,
+    SyncFromGitlabMRHandler.__name__,
+    SyncFromPagurePRHandler.__name__,
 ]

--- a/hardly/handlers/abstract.py
+++ b/hardly/handlers/abstract.py
@@ -2,11 +2,9 @@
 # SPDX-License-Identifier: MIT
 
 from enum import Enum
-from logging import getLogger
-
-logger = getLogger(__name__)
 
 
 class TaskName(str, Enum):
     dist_git_pr = "task.run_dist_git_pr_handler"
-    pipeline = "task.run_pipeline_handler"
+    sync_from_gitlab_mr = "task.run_sync_from_gitlab_mr_handler"
+    sync_from_pagure_pr = "task.run_sync_from_pagure_pr_handler"

--- a/hardly/jobs.py
+++ b/hardly/jobs.py
@@ -1,15 +1,20 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
+
 from logging import getLogger
 from typing import List
 
-from hardly.handlers import DistGitMRHandler
-from hardly.handlers.distgit import PipelineHandler
+from hardly.handlers import (
+    DistGitMRHandler,
+    SyncFromGitlabMRHandler,
+    SyncFromPagurePRHandler,
+)
 from packit_service.worker.events import (
     Event,
     MergeRequestGitlabEvent,
     PipelineGitlabEvent,
 )
+from packit_service.worker.events.pagure import PullRequestFlagPagureEvent
 from packit_service.worker.handlers import JobHandler
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.parser import Parser
@@ -56,7 +61,7 @@ class StreamJobs(SteveJobs):
                 "Skipping private repository check!"
             )
 
-        # DistGitMRHandler handler is (for now) run even the job is not configured in a package.
+        # Handlers are (for now) run even the job is not configured in a package.
         if isinstance(event_object, MergeRequestGitlabEvent):
             DistGitMRHandler.get_signature(
                 event=event_object,
@@ -64,7 +69,13 @@ class StreamJobs(SteveJobs):
             ).apply_async()
 
         if isinstance(event_object, PipelineGitlabEvent):
-            PipelineHandler.get_signature(
+            SyncFromGitlabMRHandler.get_signature(
+                event=event_object,
+                job=None,
+            ).apply_async()
+
+        if isinstance(event_object, PullRequestFlagPagureEvent):
+            SyncFromPagurePRHandler.get_signature(
                 event=event_object,
                 job=None,
             ).apply_async()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,3 +9,17 @@ from tests.spellbook import DATA_DIR
 @pytest.fixture(scope="module")
 def mr_event():
     return json.loads((DATA_DIR / "webhooks" / "gitlab" / "mr_event.json").read_text())
+
+
+@pytest.fixture(scope="module")
+def pipeline_event():
+    return json.loads((DATA_DIR / "webhooks" / "gitlab" / "pipeline.json").read_text())
+
+
+@pytest.fixture(scope="module")
+def fedora_dg_pr_flag_updated_event():
+    return json.loads(
+        (
+            DATA_DIR / "webhooks" / "gitlab" / "fedora-dg-pr-flag-updated.json"
+        ).read_text()
+    )

--- a/tests/data/webhooks/gitlab/fedora-dg-pr-flag-updated.json
+++ b/tests/data/webhooks/gitlab/fedora-dg-pr-flag-updated.json
@@ -1,0 +1,156 @@
+{
+  "topic": "org.fedoraproject.prod.pagure.pull-request.flag.updated",
+  "agent": "zuul",
+  "flag": {
+    "comment": "Jobs result is success",
+    "commit_hash": "d0143f413982f696550bddfda1a0e0cb8466c855",
+    "date_created": "1647865410",
+    "date_updated": "1647866275",
+    "percent": null,
+    "status": "success",
+    "url": "https://fedora.softwarefactory-project.io/zuul/buildset/b6d1c4f0b1db49428bc594cf74307ec6",
+    "user": {
+      "full_url": "https://src.fedoraproject.org/user/zuul",
+      "fullname": "Zuul CI Bot (Fabien Boucher)",
+      "name": "zuul",
+      "url_path": "user/zuul"
+    },
+    "username": "Zuul"
+  },
+  "pullrequest": {
+    "assignee": null,
+    "branch": "rawhide",
+    "branch_from": "1.1.4-rawhide-src-3",
+    "cached_merge_status": "FFORWARD",
+    "closed_at": null,
+    "closed_by": null,
+    "comments": [],
+    "commit_start": "d0143f413982f696550bddfda1a0e0cb8466c855",
+    "commit_stop": "d0143f413982f696550bddfda1a0e0cb8466c855",
+    "date_created": "1647865399",
+    "full_url": "https://src.fedoraproject.org/rpms/python-httpretty/pull-request/25",
+    "id": 25,
+    "initial_comment": "Testing MR for demo purposes\n\n---\n###### Info for package maintainer\nThis MR has been automatically created from\n[this source-git MR](https://gitlab.com/fedora/src/python-httpretty/-/merge_requests/3).",
+    "last_updated": "1647866076",
+    "project": {
+      "access_groups": {
+        "admin": [],
+        "collaborator": [],
+        "commit": [],
+        "ticket": []
+      },
+      "access_users": {
+        "admin": [],
+        "collaborator": [],
+        "commit": [],
+        "owner": ["jpopelka"],
+        "ticket": []
+      },
+      "close_status": [],
+      "custom_keys": [],
+      "date_created": "1501874090",
+      "date_modified": "1565074776",
+      "description": "The python-httpretty rpms",
+      "full_url": "https://src.fedoraproject.org/rpms/python-httpretty",
+      "fullname": "rpms/python-httpretty",
+      "id": 18175,
+      "milestones": {},
+      "name": "python-httpretty",
+      "namespace": "rpms",
+      "parent": null,
+      "priorities": {},
+      "tags": [],
+      "url_path": "rpms/python-httpretty",
+      "user": {
+        "full_url": "https://src.fedoraproject.org/user/jpopelka",
+        "fullname": "Ji\u0159\u00ed Popelka",
+        "name": "jpopelka",
+        "url_path": "user/jpopelka"
+      }
+    },
+    "remote_git": null,
+    "repo_from": {
+      "access_groups": {
+        "admin": [],
+        "collaborator": [],
+        "commit": [],
+        "ticket": []
+      },
+      "access_users": {
+        "admin": [],
+        "collaborator": [],
+        "commit": [],
+        "owner": ["packit"],
+        "ticket": []
+      },
+      "close_status": [],
+      "custom_keys": [],
+      "date_created": "1645546615",
+      "date_modified": "1645546615",
+      "description": "The python-httpretty rpms",
+      "full_url": "https://src.fedoraproject.org/fork/packit/rpms/python-httpretty",
+      "fullname": "forks/packit/rpms/python-httpretty",
+      "id": 55318,
+      "milestones": {},
+      "name": "python-httpretty",
+      "namespace": "rpms",
+      "parent": {
+        "access_groups": {
+          "admin": [],
+          "collaborator": [],
+          "commit": [],
+          "ticket": []
+        },
+        "access_users": {
+          "admin": [],
+          "collaborator": [],
+          "commit": [],
+          "owner": ["jpopelka"],
+          "ticket": []
+        },
+        "close_status": [],
+        "custom_keys": [],
+        "date_created": "1501874090",
+        "date_modified": "1565074776",
+        "description": "The python-httpretty rpms",
+        "full_url": "https://src.fedoraproject.org/rpms/python-httpretty",
+        "fullname": "rpms/python-httpretty",
+        "id": 18175,
+        "milestones": {},
+        "name": "python-httpretty",
+        "namespace": "rpms",
+        "parent": null,
+        "priorities": {},
+        "tags": [],
+        "url_path": "rpms/python-httpretty",
+        "user": {
+          "full_url": "https://src.fedoraproject.org/user/jpopelka",
+          "fullname": "Ji\u0159\u00ed Popelka",
+          "name": "jpopelka",
+          "url_path": "user/jpopelka"
+        }
+      },
+      "priorities": {},
+      "tags": [],
+      "url_path": "fork/packit/rpms/python-httpretty",
+      "user": {
+        "full_url": "https://src.fedoraproject.org/user/packit",
+        "fullname": "Packit Bot",
+        "name": "packit",
+        "url_path": "user/packit"
+      }
+    },
+    "status": "Open",
+    "tags": [],
+    "threshold_reached": null,
+    "title": "Fixes #425. (#436)",
+    "uid": "3a908dd9569d48129bbad0be3b1eb23e",
+    "updated_on": "1647865399",
+    "user": {
+      "full_url": "https://src.fedoraproject.org/user/packit",
+      "fullname": "Packit Bot",
+      "name": "packit",
+      "url_path": "user/packit"
+    }
+  }
+}

--- a/tests/data/webhooks/gitlab/pipeline.json
+++ b/tests/data/webhooks/gitlab/pipeline.json
@@ -1,0 +1,110 @@
+{
+  "object_kind": "pipeline",
+  "object_attributes": {
+    "id": 497396723,
+    "ref": "11.3.0-c9s-src-15",
+    "tag": false,
+    "sha": "5e8406e38c0bc7bc105e291c408913971126fe40",
+    "before_sha": "0000000000000000000000000000000000000000",
+    "source": "merge_request_event",
+    "status": "failed",
+    "detailed_status": "failed",
+    "stages": ["test"],
+    "created_at": "2022-03-21 17:00:31 UTC",
+    "finished_at": "2022-03-21 17:00:46 UTC",
+    "duration": 13,
+    "queued_duration": 1,
+    "variables": []
+  },
+  "merge_request": {
+    "id": 120325047,
+    "iid": 25,
+    "title": "dummy",
+    "source_branch": "11.3.0-c9s-src-15",
+    "source_project_id": 30219532,
+    "target_branch": "c9s",
+    "target_project_id": 28084873,
+    "state": "opened",
+    "merge_status": "can_be_merged",
+    "url": "https://gitlab.com/packit-service/rpms/open-vm-tools/-/merge_requests/25"
+  },
+  "user": {
+    "id": 6307839,
+    "name": "Packit Stage Service",
+    "username": "packit-as-a-service-stg",
+    "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/6307839/avatar.png",
+    "email": "[REDACTED]"
+  },
+  "project": {
+    "id": 30219532,
+    "name": "open-vm-tools",
+    "description": "Copy of https://gitlab.com/redhat/centos-stream/rpms/open-vm-tools for testing purposes",
+    "web_url": "https://gitlab.com/packit-as-a-service-stg/open-vm-tools",
+    "avatar_url": null,
+    "git_ssh_url": "git@gitlab.com:packit-as-a-service-stg/open-vm-tools.git",
+    "git_http_url": "https://gitlab.com/packit-as-a-service-stg/open-vm-tools.git",
+    "namespace": "Packit Stage Service",
+    "visibility_level": 20,
+    "path_with_namespace": "packit-as-a-service-stg/open-vm-tools",
+    "default_branch": "c9s",
+    "ci_config_path": ""
+  },
+  "commit": {
+    "id": "5e8406e38c0bc7bc105e291c408913971126fe40",
+    "message": "dummy\n\nFrom-source-git-commit: 06f212c897c62ec08fc6c6ee2cf6df8789cd3218\n\n---\n###### Info for package maintainer\nThis MR has been automatically created from\n[this source-git MR](https://gitlab.com/packit-service/src/open-vm-tools/-/merge_requests/15).\nPlease review the contribution and once you are comfortable with the content,\nyou should trigger a CI pipeline run via `Pipelines → Run pipeline`.\n\nSigned-off-by: Packit Service <user-cont-team+packit-service@redhat.com>\n",
+    "title": "dummy",
+    "timestamp": "2022-03-21T17:00:24+00:00",
+    "url": "https://gitlab.com/packit-as-a-service-stg/open-vm-tools/-/commit/5e8406e38c0bc7bc105e291c408913971126fe40",
+    "author": {
+      "name": "Packit Service",
+      "email": "user-cont-team+packit-service@redhat.com"
+    }
+  },
+  "builds": [
+    {
+      "id": 2230338033,
+      "stage": "test",
+      "name": "check-gitbz",
+      "status": "failed",
+      "created_at": "2022-03-21 17:00:31 UTC",
+      "started_at": "2022-03-21 17:00:32 UTC",
+      "finished_at": "2022-03-21 17:00:46 UTC",
+      "duration": 13.423369,
+      "queued_duration": 0.735017,
+      "when": "on_success",
+      "manual": false,
+      "allow_failure": false,
+      "user": {
+        "id": 6307839,
+        "name": "Packit Stage Service",
+        "username": "packit-as-a-service-stg",
+        "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/6307839/avatar.png",
+        "email": "[REDACTED]"
+      },
+      "runner": {
+        "id": 12270845,
+        "description": "1-green.shared.runners-manager.gitlab.com/default",
+        "runner_type": "instance_type",
+        "active": true,
+        "is_shared": true,
+        "tags": [
+          "gce",
+          "east-c",
+          "linux",
+          "ruby",
+          "mysql",
+          "postgres",
+          "mongo",
+          "git-annex",
+          "shared",
+          "docker"
+        ]
+      },
+      "artifacts_file": {
+        "filename": null,
+        "size": null
+      },
+      "environment": null
+    }
+  ]
+}

--- a/tests/integration/test_dist_git_mr.py
+++ b/tests/integration/test_dist_git_mr.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 from flexmock import flexmock
+
+from hardly.tasks import run_dist_git_sync_handler
 from packit.api import PackitAPI
 from packit.config.job_config import JobConfigTriggerType
 from packit.local_project import LocalProject
@@ -11,8 +13,6 @@ from packit_service.service.db_triggers import AddPullRequestDbTrigger
 from packit_service.utils import dump_package_config
 from packit_service.worker.monitoring import Pushgateway
 from packit_service.worker.parser import Parser
-
-from hardly.tasks import run_dist_git_sync_handler
 from tests.spellbook import first_dict_value
 
 

--- a/tests/integration/test_sync_from_dist_git.py
+++ b/tests/integration/test_sync_from_dist_git.py
@@ -1,0 +1,91 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+import pytest
+from flexmock import flexmock
+
+from hardly.handlers import SyncFromPagurePRHandler, SyncFromGitlabMRHandler
+from packit_service.config import ServiceConfig
+from packit_service.models import SourceGitPRDistGitPRModel
+from packit_service.worker.events.pagure import PullRequestFlagPagureEvent
+from packit_service.worker.parser import Parser
+from packit_service.worker.reporting import (
+    BaseCommitStatus,
+    StatusReporter,
+)
+
+
+@pytest.mark.parametrize(
+    "event, src_project_url, status_state, status_description, status_check_name, status_url",
+    [
+        pytest.param(
+            "fedora_dg_pr_flag_updated_event",
+            "https://gitlab.com/fedora/src/python-httpretty",
+            BaseCommitStatus.success,
+            "Jobs result is success",
+            "Zuul",
+            "https://fedora.softwarefactory-project.io/"
+            "zuul/buildset/b6d1c4f0b1db49428bc594cf74307ec6",
+            id="Fedora Pagure flag",
+        ),
+        pytest.param(
+            "pipeline_event",
+            "https://gitlab.com/packit-service/src/open-vm-tools",
+            BaseCommitStatus.failure,
+            "Changed status to failed",
+            "Dist-git MR CI Pipeline",
+            "https://gitlab.com/packit-as-a-service-stg/open-vm-tools/-/pipelines/497396723",
+            id="Stream Gitlab pipeline",
+        ),
+    ],
+)
+def test_sync_from_dist_git(
+    event,
+    src_project_url,
+    status_state,
+    status_description,
+    status_check_name,
+    status_url,
+    request,
+):
+    event = Parser.parse_event(request.getfixturevalue(event))
+    handler = (
+        SyncFromPagurePRHandler
+        if isinstance(event, PullRequestFlagPagureEvent)
+        else SyncFromGitlabMRHandler
+    )
+
+    dist_git_pr_model = flexmock(id=2)
+    flexmock(handler).should_receive("dist_git_pr_model").and_return(dist_git_pr_model)
+
+    source_git_pr = flexmock(id=123, head_commit="foobar")
+    source_git_project = flexmock(
+        project_url=src_project_url,
+        get_pr=source_git_pr,
+    )
+    source_git_pr_model = flexmock(pr_id=123, project=source_git_project)
+    source_git_pr_dist_git_pr_model = flexmock(
+        source_git_pull_request=source_git_pr_model
+    )
+    flexmock(SourceGitPRDistGitPRModel).should_receive("get_by_dist_git_id").with_args(
+        2
+    ).and_return(source_git_pr_dist_git_pr_model)
+    flexmock(ServiceConfig).should_receive("get_project").with_args(
+        url=src_project_url
+    ).and_return(source_git_project)
+
+    status_reporter = flexmock()
+    status_reporter.should_receive("set_status").with_args(
+        state=status_state,
+        description=status_description,
+        check_name=status_check_name,
+        url=status_url,
+    )
+    flexmock(StatusReporter).should_receive("get_instance").with_args(
+        project=source_git_project, commit_sha="foobar", pr_id=123
+    ).and_return(status_reporter)
+
+    handler(
+        package_config=None,
+        event=event.get_dict(),
+        job_config=None,
+    ).run()


### PR DESCRIPTION
- `PipelineHandler` renamed to `SyncFromGitlabMRHandler`
- The new handler is called `SyncFromPagurePRHandler` and they have common `SyncFromDistGitPRHandler` parent class.
- Origin source-git PR for the to-be-synced-from dist-git PR is retrieved from database.

Fixes #44 

Merge after packit/packit-service#1401 #51 packit/packit-service#1390