### PR TITLE
Dist-git MR's target branch to match source-git MR's target branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,8 @@ Related to
 
 Merge before/after
 
----
+RELEASE NOTES BEGIN
 
-<!-- release notes for changelog/blog follow -->
+Packit now supports automatic ordering of ☕ after all checks pass.
+
+RELEASE NOTES END

--- a/hardly/handlers/distgit.py
+++ b/hardly/handlers/distgit.py
@@ -12,6 +12,7 @@ from packit.api import PackitAPI
 from packit.config.job_config import JobConfig
 from packit.config.package_config import PackageConfig
 from packit.local_project import LocalProject
+from packit.exceptions import PackitGitException
 from packit_service.models import PullRequestModel, SourceGitPRDistGitPRModel
 from packit_service.worker.events import MergeRequestGitlabEvent, PipelineGitlabEvent
 from packit_service.worker.events.pagure import PullRequestFlagPagureEvent
@@ -51,6 +52,26 @@ class DistGitMRHandler(JobHandler):
         )
         self.target_repo_branch = event["target_repo_branch"]
 
+    def get_dist_git_branch(self) -> str:
+        """Get the downstream repo branch name where to open the MR.
+        If it exist otherwise raise an exception.
+
+        Returns:
+            The downstream repo branch name
+        Raises:
+            PackitGitException: if the branch is not found
+        """
+        dist_git_branch = (
+            self.package_config.downstream_branch_name or self.target_repo_branch
+        )
+        if dist_git_branch not in self.api.dg.local_project.git_project.get_branches():
+            msg = f"""
+Downstream {self.target_repo}:{dist_git_branch} branch does not exist.
+"""
+            raise PackitGitException(msg)
+
+        return dist_git_branch
+
     def run(self) -> TaskResults:
         """
         If user creates a merge-request on the source-git repository,
@@ -88,17 +109,28 @@ This MR has been automatically created from
             dg_mr_info += """
 Please review the contribution and once you are comfortable with the content,
 you should trigger a CI pipeline run via `Pipelines → Run pipeline`."""
-        dg_mr = self.api.sync_release(
-            dist_git_branch=self.package_config.downstream_branch_name,
-            version=self.api.up.get_specfile_version(),
-            add_new_sources=False,
-            title=self.mr_title,
-            description=f"{self.mr_description}\n\n---\n{dg_mr_info}",
-            sync_default_files=False,
-            # we rely on this in PipelineHandler below
-            local_pr_branch_suffix=f"src-{self.mr_identifier}",
-            mark_commit_origin=True,
-        )
+
+        dist_git_branch = None
+        try:
+            dist_git_branch = self.get_dist_git_branch()
+        except PackitGitException as ex:
+            msg = str(ex)
+            self.project.get_pr(int(self.mr_identifier)).comment(msg)
+            logger.debug(msg)
+
+        dg_mr = None
+        if dist_git_branch:
+            dg_mr = self.api.sync_release(
+                dist_git_branch=dist_git_branch,
+                version=self.api.up.get_specfile_version(),
+                add_new_sources=False,
+                title=self.mr_title,
+                description=f"{self.mr_description}\n\n---\n{dg_mr_info}",
+                sync_default_files=False,
+                # we rely on this in PipelineHandler below
+                local_pr_branch_suffix=f"src-{self.mr_identifier}",
+                mark_commit_origin=True,
+            )
 
         if dg_mr:
             comment = f"""[Dist-git MR #{dg_mr.id}]({dg_mr.url})

--- a/hardly/handlers/distgit.py
+++ b/hardly/handlers/distgit.py
@@ -89,6 +89,7 @@ This MR has been automatically created from
 Please review the contribution and once you are comfortable with the content,
 you should trigger a CI pipeline run via `Pipelines → Run pipeline`."""
         dg_mr = self.api.sync_release(
+            dist_git_branch=self.package_config.downstream_branch_name,
             version=self.api.up.get_specfile_version(),
             add_new_sources=False,
             title=self.mr_title,

--- a/tests/integration/test_dist_git_mr.py
+++ b/tests/integration/test_dist_git_mr.py
@@ -1,5 +1,6 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
+import pytest
 from flexmock import flexmock
 
 from hardly.tasks import run_dist_git_sync_handler
@@ -13,41 +14,89 @@ from packit_service.service.db_triggers import AddPullRequestDbTrigger
 from packit_service.utils import dump_package_config
 from packit_service.worker.monitoring import Pushgateway
 from packit_service.worker.parser import Parser
-from ogr.services.gitlab import GitlabProject
+from ogr.services.gitlab import GitlabProject, GitlabPullRequest
+from ogr.services.pagure import PagureProject
 from tests.spellbook import first_dict_value
 
 
-def test_dist_git_mr(mr_event):
-    source_git_yaml = """ {
-        "upstream_project_url": "https://github.com/vmware/open-vm-tools.git",
-        "upstream_ref": "stable-11.3.0",
-        "downstream_package_name": "open-vm-tools",
-        "downstream_branch_name": "another-rawhide",
-        "specfile_path": ".distro/open-vm-tools.spec",
-        "patch_generation_ignore_paths": [".distro"],
-        "patch_generation_patch_id_digits": 1,
-        "sync_changelog": True,
-        "synced_files": [
-            {
-                "src": ".distro/",
-                "dest": ".",
-                "delete": True,
-                "filters": [
-                    "protect .git*",
-                    "protect sources",
-                    "exclude source-git.yaml",
-                    "exclude .gitignore",
-                ],
-            }
-        ],
-        "sources": [
-            {
-                "path": "open-vm-tools-11.3.0-18090558.tar.gz",
-                "url": "https://sources.stream.centos.org/sources/rpms/open-vm-tools/...",
-            }
-        ],
-    }
-    """
+source_git_yaml = """ {
+    "upstream_project_url": "https://github.com/vmware/open-vm-tools.git",
+    "upstream_ref": "stable-11.3.0",
+    "downstream_package_name": "open-vm-tools",
+    "specfile_path": ".distro/open-vm-tools.spec",
+    "patch_generation_ignore_paths": [".distro"],
+    "patch_generation_patch_id_digits": 1,
+    "sync_changelog": True,
+    "synced_files": [
+        {
+            "src": ".distro/",
+            "dest": ".",
+            "delete": True,
+            "filters": [
+                "protect .git*",
+                "protect sources",
+                "exclude source-git.yaml",
+                "exclude .gitignore",
+            ],
+        }
+    ],
+    "sources": [
+        {
+            "path": "open-vm-tools-11.3.0-18090558.tar.gz",
+            "url": "https://sources.stream.centos.org/sources/rpms/open-vm-tools/...",
+        }
+    ],
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "source_git_yaml, downstream_branches, expected_branch, notify_msg",
+    [
+        pytest.param(
+            source_git_yaml,
+            ["master", "c9s"],
+            "c9s",
+            False,
+            id="Use upstream branch name in downstream",
+        ),
+        pytest.param(
+            source_git_yaml.replace(
+                """
+    "downstream_package_name": "open-vm-tools",
+""",
+                """
+    "downstream_package_name": "open-vm-tools",
+    "downstream_branch_name": "another-rawhide",
+""",
+            ),
+            ["master", "another-rawhide"],
+            "another-rawhide",
+            False,
+            id="Use custom downstream branch name",
+        ),
+        pytest.param(
+            source_git_yaml.replace(
+                """
+    "downstream_package_name": "open-vm-tools",
+""",
+                """
+    "downstream_package_name": "open-vm-tools",
+    "downstream_branch_name": "unknown",
+""",
+            ),
+            [
+                "master",
+            ],
+            "unknown",
+            True,
+            id="Create new downstream branch and notify user",
+        ),
+    ],
+)
+def test_dist_git_mr(
+    mr_event, source_git_yaml, downstream_branches, expected_branch, notify_msg
+):
     version = "11.3.0"
 
     trigger = flexmock(
@@ -68,6 +117,9 @@ def test_dist_git_mr(mr_event):
         LocalProject, refresh_the_arguments=lambda: None, checkout_ref=lambda ref: None
     )
     lp.git_project = source_project
+    flexmock(PagureProject).should_receive("get_branches").and_return(
+        downstream_branches
+    )
     flexmock(Upstream).should_receive("get_specfile_version").and_return(version)
 
     config = ServiceConfig()
@@ -75,12 +127,18 @@ def test_dist_git_mr(mr_event):
     config.gitlab_mr_targets_handled = None
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(config)
     flexmock(Pushgateway).should_receive("push").once().and_return()
-    flexmock(PackitAPI).should_receive("sync_release").with_args(
-        dist_git_branch="another-rawhide",
-        version=version,
-        add_new_sources=False,
-        title="Yet another testing MR",
-        description="""DnD RpcV3: A corrupted packet received may result in an out of bounds (OOB)
+    if notify_msg:
+        flexmock(GitlabPullRequest).should_receive("comment").and_return()
+    else:
+        (
+            flexmock(PackitAPI)
+            .should_receive("sync_release")
+            .with_args(
+                dist_git_branch=expected_branch,
+                version=version,
+                add_new_sources=False,
+                title="Yet another testing MR",
+                description="""DnD RpcV3: A corrupted packet received may result in an out of bounds (OOB)
 memory access if the length of the message received is less than the size
 of the expected packet header.
 
@@ -88,10 +146,12 @@ of the expected packet header.
 ###### Info for package maintainer
 This MR has been automatically created from
 [this source-git MR](https://gitlab.com/packit-service/src/open-vm-tools/-/merge_requests/5).""",
-        sync_default_files=False,
-        local_pr_branch_suffix="src-5",
-        mark_commit_origin=True,
-    ).once()
+                sync_default_files=False,
+                local_pr_branch_suffix="src-5",
+                mark_commit_origin=True,
+            )
+            .once()
+        )
 
     event = Parser.parse_event(mr_event)
     results = run_dist_git_sync_handler(


### PR DESCRIPTION
NOTE: tests are failing for the same reason already appeared in packit/hardly#55

Fixes packit/hardly#36

Merge after packit/packit#1555

Related with packit/packit.dev#430

RELEASE NOTES BEGIN

The user can now customize the name of the downstream branch using the `downstream_branch_name` configuration option.

RELEASE NOTES END
