### PR TITLE
Do not use `downstream_branch_name` option

### DIFF
--- a/hardly/handlers/distgit.py
+++ b/hardly/handlers/distgit.py
@@ -12,7 +12,6 @@ from packit.api import PackitAPI
 from packit.config.job_config import JobConfig
 from packit.config.package_config import PackageConfig
 from packit.local_project import LocalProject
-from packit.exceptions import PackitGitException
 from packit_service.models import PullRequestModel, SourceGitPRDistGitPRModel
 from packit_service.worker.events import MergeRequestGitlabEvent, PipelineGitlabEvent
 from packit_service.worker.events.pagure import PullRequestFlagPagureEvent
@@ -52,26 +51,6 @@ class DistGitMRHandler(JobHandler):
         )
         self.target_repo_branch = event["target_repo_branch"]
 
-    def get_dist_git_branch(self) -> str:
-        """Get the downstream repo branch name where to open the MR.
-        If it exist otherwise raise an exception.
-
-        Returns:
-            The downstream repo branch name
-        Raises:
-            PackitGitException: if the branch is not found
-        """
-        dist_git_branch = (
-            self.package_config.downstream_branch_name or self.target_repo_branch
-        )
-        if dist_git_branch not in self.api.dg.local_project.git_project.get_branches():
-            msg = f"""
-Downstream {self.target_repo}:{dist_git_branch} branch does not exist.
-"""
-            raise PackitGitException(msg)
-
-        return dist_git_branch
-
     def run(self) -> TaskResults:
         """
         If user creates a merge-request on the source-git repository,
@@ -110,13 +89,18 @@ This MR has been automatically created from
 Please review the contribution and once you are comfortable with the content,
 you should trigger a CI pipeline run via `Pipelines → Run pipeline`."""
 
-        dist_git_branch = None
-        try:
-            dist_git_branch = self.get_dist_git_branch()
-        except PackitGitException as ex:
-            msg = str(ex)
+        if (
+            self.target_repo_branch
+            in self.api.dg.local_project.git_project.get_branches()
+        ):
+            dist_git_branch = self.target_repo_branch
+        else:
+            msg = f"""
+Downstream {self.target_repo}:{self.target_repo_branch} branch does not exist.
+"""
             self.project.get_pr(int(self.mr_identifier)).comment(msg)
             logger.debug(msg)
+            dist_git_branch = None
 
         dg_mr = None
         if dist_git_branch:

--- a/tests/integration/test_dist_git_mr.py
+++ b/tests/integration/test_dist_git_mr.py
@@ -67,30 +67,14 @@ source_git_yaml = """ {
 """,
                 """
     "downstream_package_name": "open-vm-tools",
-    "downstream_branch_name": "another-rawhide",
-""",
-            ),
-            ["master", "another-rawhide"],
-            "another-rawhide",
-            False,
-            id="Use custom downstream branch name",
-        ),
-        pytest.param(
-            source_git_yaml.replace(
-                """
-    "downstream_package_name": "open-vm-tools",
-""",
-                """
-    "downstream_package_name": "open-vm-tools",
-    "downstream_branch_name": "unknown",
 """,
             ),
             [
                 "master",
             ],
-            "unknown",
+            "c9s",
             True,
-            id="Create new downstream branch and notify user",
+            id="Notify user that branch does not exist",
         ),
     ],
 )


### PR DESCRIPTION
We will wait for the `dist_git_branch` option
to be available also in source-git.
See comments on packit/packit.dev#430

RELEASE NOTES BEGIN
RELEASE NOTES END
