### PR TITLE
Fix CI in zuul

### DIFF
--- a/files/zuul-tests.yaml
+++ b/files/zuul-tests.yaml
@@ -12,6 +12,13 @@
           - podman
         state: present
       become: true
+    # Fix the SELinux context for podman
+    - name: Create ~/.local/share/
+      file:
+        path: ~/.local/share/
+        state: directory
+        recurse: yes
+        setype: data_home_t
     - name: Build test image
       command: "make test-image"
       args:


### PR DESCRIPTION
For some (unknown) reason `/home/zuul-worker/.local/share/containers` selinux permissions are wrong and podman does not run properly.
Creating the directory before running podman with the right permissions made the trick.

Ref. https://github.com/containers/podman/issues/10817

Fix packit/packit-service#1456