### PR TITLE
DistGitMRHandler: fetch tags from upstream source-git

### DIFF
--- a/hardly/handlers/distgit.py
+++ b/hardly/handlers/distgit.py
@@ -100,6 +100,9 @@ class DistGitMRHandler(JobHandler):
                 ref=self.data.commit_sha,
                 working_dir=self.service_config.command_handler_work_dir,
             )
+            # We need to fetch tags from the upstream source-git repo
+            # Details: https://github.com/packit/hardly/issues/61
+            local_project.fetch(self.project.get_web_url())
 
             self._packit = PackitAPI(
                 config=self.service_config,

--- a/tests/integration/test_dist_git_mr.py
+++ b/tests/integration/test_dist_git_mr.py
@@ -101,7 +101,12 @@ def test_dist_git_mr(
     ).and_return(None)
 
     lp = flexmock(
-        LocalProject, refresh_the_arguments=lambda: None, checkout_ref=lambda ref: None
+        LocalProject,
+        refresh_the_arguments=lambda: None,
+        checkout_ref=lambda ref: None,
+    )
+    lp.should_receive("fetch").with_args(
+        "https://gitlab.com/packit-service/src/open-vm-tools"
     )
     flexmock(PagureProject).should_receive("get_branches").and_return(
         downstream_branches

--- a/tests/integration/test_dist_git_mr.py
+++ b/tests/integration/test_dist_git_mr.py
@@ -89,12 +89,6 @@ def test_dist_git_mr(
     )
     flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(trigger)
 
-    source_project = flexmock(
-        namespace="jpopelka",
-        repo="src-open-vm-tools",
-        get_file_content=lambda path, ref: source_git_yaml,
-        full_repo_name="jpopelka/src-open-vm-tools",
-    )
     flexmock(GitlabProject).should_receive("get_file_content").and_return(
         source_git_yaml
     )
@@ -109,7 +103,6 @@ def test_dist_git_mr(
     lp = flexmock(
         LocalProject, refresh_the_arguments=lambda: None, checkout_ref=lambda ref: None
     )
-    lp.git_project = source_project
     flexmock(PagureProject).should_receive("get_branches").and_return(
         downstream_branches
     )


### PR DESCRIPTION
We clone source-git fork by default - it does not need to have upstream
tags that are needed in the update-dist-git process.

This commit fetches tags from upstream (the repo against the MR is
opened) after the repo is cloned (initialization of LocalProject).

Fixes https://github.com/packit/hardly/issues/61

RELEASE NOTES BEGIN

When a dist-git MR is being created, hardly now fetches tags from the upstream source-git repo as they may not be present in contributor's fork.

RELEASE NOTES END