### PR TITLE
Add a log message to debug missing merge_request_url

### DIFF
--- a/hardly/handlers/distgit.py
+++ b/hardly/handlers/distgit.py
@@ -354,10 +354,12 @@ class SyncFromGitlabMRHandler(SyncFromDistGitPRHandler):
 
     def dist_git_pr_model(self) -> Optional[PullRequestModel]:
         if self.source == "merge_request_event":
+            if not self.merge_request_url:
+                logger.debug(f"No merge_request_url in {self.data.event_dict}")
+                return None
             # Derive project from merge_request_url because
             # self.project can be either source or target
-            m = fullmatch(r"(\S+)/-/merge_requests/(\d+)", self.merge_request_url)
-            if m:
+            if m := fullmatch(r"(\S+)/-/merge_requests/(\d+)", self.merge_request_url):
                 project = self.service_config.get_project(url=m[1])
                 return PullRequestModel.get_or_create(
                     pr_id=int(m[2]),


### PR DESCRIPTION
to know whether it was a flake or there's some pattern.
[packit_service/worker/parser.py#L1193](https://github.com/packit/packit-service/blob/da4a797985708b814e744a7c19610f00384d6729/packit_service/worker/parser.py#L1193)
says that the `merge_request` can be missing in the original webhook payload if the `source` is `push`, but in the
https://sentry.io/organizations/red-hat-0p/issues/3427461150
case the `source` was `merge_request_event`.

The trigger was
https://gitlab.com/redhat/centos-stream/rpms/gnome-settings-daemon/-/pipelines/588479707
from
https://gitlab.com/redhat/centos-stream/rpms/gnome-settings-daemon/-/merge_requests/7
which doesn't look anyhow special.

Unfortunately, [we don't know what was in the payload](https://github.com/packit/packit-service/issues/1512), so let's add some debug logging to have some clues next time.