### PR TITLE
Update dist-git merge-request

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ but is expected to eventually follow [this workflow](https://github.com/packit/r
 
 ##### Should have:
 
-- [ ] If the source-git merge-request is updated, update the dist-git merge-request.
+- [x] If the source-git merge-request is updated, update the dist-git merge-request.
 - [x] If the source-git merge-request is closed, close the dist-git merge-request.
 
 ##### Could have:


### PR DESCRIPTION
Update the dist-git merge-request when the source-git merge-request is updated with new code.

1. Get `oldrev` from the event
2. If `oldrev` is defined , the merge-request has been updated with new code
3. Extract the `sync_release` function from the `run` function
4. Run `sync_release` when `oldrev` is defined

Merge after  packit/packit#1725
