### PR TITLE
Pass account name to StatusReporter

### DIFF
--- a/hardly/handlers/distgit.py
+++ b/hardly/handlers/distgit.py
@@ -277,6 +277,16 @@ class SyncFromDistGitPRHandler(JobHandler):
     def dist_git_pr_model(self) -> Optional[PullRequestModel]:
         raise NotImplementedError("This should have been implemented.")
 
+    @staticmethod
+    def get_gitlab_account_name() -> str:
+        # https://github.com/packit/ogr/issues/751
+        return {
+            "stream-prod": "centos-stream-packit",
+            "stream-stg": "packit-as-a-service-stg",
+            "fedora-source-git-prod": "packit-as-a-service",
+            "fedora-source-git-stg": "packit-as-a-service-stg",
+        }[getenv("PROJECT", "stream-stg")]
+
     def run(self) -> TaskResults:
         """
         When a dist-git PR flag/pipeline is updated, create a commit
@@ -303,7 +313,7 @@ class SyncFromDistGitPRHandler(JobHandler):
             # If there was a new commit pushed before the pipeline ended, the report
             # might be incorrect until the new (for the new commit) pipeline finishes.
             commit_sha=source_git_pr.head_commit,
-            pr_id=source_git_pr.id,
+            packit_user=self.get_gitlab_account_name(),
         )
         # Our account(s) have no access (unless it's manually added) into the fork repos,
         # to set the commit status (which would look like a Pipeline result)

--- a/tests/integration/test_sync_from_dist_git.py
+++ b/tests/integration/test_sync_from_dist_git.py
@@ -81,7 +81,9 @@ def test_sync_from_dist_git(
         url=status_url,
     )
     flexmock(StatusReporter).should_receive("get_instance").with_args(
-        project=source_git_project, commit_sha="foobar", pr_id=123
+        project=source_git_project,
+        commit_sha="foobar",
+        packit_user="packit-as-a-service-stg",
     ).and_return(status_reporter)
 
     handler(


### PR DESCRIPTION
so that it can check for duplicated comments.

We do the same ([hardcoding of account names](https://github.com/packit/packit-service/blob/96a59e7b1ca4ecf2c68633ec64ff4f01a9f5cea0/packit_service/config.py#L268)) in packit-service as well.

Fixes: #83
