### PR TITLE
Use environment files instead of set-output command

### DIFF
--- a/.github/workflows/rebuild-and-push-images.yml
+++ b/.github/workflows/rebuild-and-push-images.yml
@@ -18,7 +18,7 @@ jobs:
             image: hardly
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Extract branch name and set tag
         shell: bash
@@ -33,9 +33,9 @@ jobs:
                   tag="prod"
                   ;;
           esac
-          echo "::set-output name=branch::${branch}"
+          echo "branch=${branch}" >> $GITHUB_OUTPUT
           unique_tag="${branch}-${GITHUB_SHA::7}-$(date +%s)"
-          echo "::set-output name=tag::${tag} ${unique_tag}"
+          echo "tag=${tag} ${unique_tag}" >> $GITHUB_OUTPUT
         id: branch_tag
 
       - name: Build Image


### PR DESCRIPTION
Related to packit/deployment#396

- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter