### PR TITLE
Don't install rsync from Copr

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,19 +4,19 @@
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.0
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+    rev: v3.0.0-alpha.4
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -31,20 +31,20 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
         args:
           - --max-line-length=100
           - --per-file-ignores=files/packit.wsgi:F401,E402
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.990
+    rev: v0.991
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]
         additional_dependencies: [types-pkg_resources]
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.8.0.4
+    rev: v0.9.0.2
     hooks:
       - id: shellcheck
   - repo: https://github.com/packit/pre-commit-hooks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,9 +46,9 @@ services:
       PUSHGATEWAY_ADDRESS: ""
     volumes:
       - ./hardly:/src/hardly:ro,z
-      - ../ogr/ogr:/usr/local/lib/python3.10/site-packages/ogr:ro,z
-      - ../packit/packit:/usr/local/lib/python3.10/site-packages/packit:ro,z
-      - ../packit-service/packit_service:/usr/local/lib/python3.10/site-packages/packit_service:ro,z
+      - ../ogr/ogr:/usr/local/lib/python3.11/site-packages/ogr:ro,z
+      - ../packit/packit:/usr/local/lib/python3.11/site-packages/packit:ro,z
+      - ../packit-service/packit_service:/usr/local/lib/python3.11/site-packages/packit_service:ro,z
       - ./secrets/${SERVICE}/dev/packit-service.yaml:/home/packit/.config/packit-service.yaml:ro,z
       - ./secrets/${SERVICE}/dev/id_rsa.pub:/packit-ssh/id_rsa.pub:ro,z
       - ./secrets/${SERVICE}/dev/id_rsa:/packit-ssh/id_rsa:ro,z
@@ -71,9 +71,9 @@ services:
       POSTGRESQL_HOST: postgres
       POSTGRESQL_DATABASE: packit
     volumes:
-      - ../ogr/ogr:/usr/local/lib/python3.10/site-packages/ogr:ro,z
-      - ../packit/packit:/usr/local/lib/python3.10/site-packages/packit:ro,z
-      - ../packit-service/packit_service:/usr/local/lib/python3.10/site-packages/packit_service:ro,z
+      - ../ogr/ogr:/usr/local/lib/python3.11/site-packages/ogr:ro,z
+      - ../packit/packit:/usr/local/lib/python3.11/site-packages/packit:ro,z
+      - ../packit-service/packit_service:/usr/local/lib/python3.11/site-packages/packit_service:ro,z
       - ../packit-service/alembic:/src/alembic:ro,z
       - ./secrets/${SERVICE}/dev/packit-service.yaml:/home/packit/.config/packit-service.yaml:ro,z
       - ./secrets/${SERVICE}/dev/fullchain.pem:/secrets/fullchain.pem:ro,z

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -13,10 +13,3 @@
         name:
           - centpkg
           - tig # for debugging, can be removed later
-    - name: Downgrade rsync
-      ansible.builtin.dnf:
-        name:
-          # Fixes rsync error: protocol incompatibility (code 2) at flist.c(994) [Receiver=3.2.5]
-          # https://bugzilla.redhat.com/show_bug.cgi?id=2123815#c9
-          - https://download.copr.fedorainfracloud.org/results/jpopelka/rsync/fedora-35-x86_64/04838549-rsync/rsync-3.2.6-2.fc35.x86_64.rpm
-        disable_gpg_check: true


### PR DESCRIPTION
Worker image already contains rsync-3.2.7 with the bugfix.

Reverts 32c05af79