### PR TITLE
Make hardly great again

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   redis:
-    image: quay.io/centos7/redis-5-centos7
+    image: quay.io/sclorg/redis-6-c9s
     container_name: redis
     ports:
       - 6379:6379
@@ -10,7 +10,7 @@ services:
 
   postgres:
     container_name: postgres
-    image: quay.io/centos7/postgresql-13-centos7
+    image: quay.io/sclorg/postgresql-13-c9s
     environment:
       POSTGRESQL_USER: packit
       POSTGRESQL_PASSWORD: secret-password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       DISTGIT_NAMESPACE: ${DISTGIT_NAMESPACE}
       CELERY_RETRY_LIMIT: 0
       PUSHGATEWAY_ADDRESS: ""
+    #       DEBUGPY: True
     volumes:
       - ./hardly:/src/hardly:ro,z
       - ../ogr/ogr:/usr/local/lib/python3.11/site-packages/ogr:ro,z

--- a/files/Containerfile
+++ b/files/Containerfile
@@ -23,7 +23,4 @@ RUN git rev-parse HEAD >/.hardly.git.commit.hash \
     && git show --quiet --format=%B HEAD >/.hardly.git.commit.message \
     && ansible-playbook -vv -c local -i localhost, files/recipe-hardly.yaml
 
-# Allow remote debugging
-RUN pip install --upgrade debugpy
-
 COPY hardly/ ./hardly/

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -13,3 +13,7 @@
         name:
           - centpkg
           - tig # for debugging, can be removed later
+    - name: Install pip deps
+      ansible.builtin.pip:
+        name:
+          - debugpy # Allow remote debugging

--- a/hardly/handlers/distgit.py
+++ b/hardly/handlers/distgit.py
@@ -17,10 +17,7 @@ from packit_service.models import PullRequestModel, SourceGitPRDistGitPRModel
 from packit_service.worker.events import MergeRequestGitlabEvent, PipelineGitlabEvent
 from packit_service.worker.events.enums import GitlabEventAction
 from packit_service.worker.events.pagure import PullRequestFlagPagureEvent
-from packit_service.worker.handlers import JobHandler
-from packit_service.worker.handlers.abstract import (
-    reacts_to,
-)
+from packit_service.worker.handlers.abstract import JobHandler, reacts_to
 from packit_service.worker.mixin import (
     ConfigFromEventMixin,
     PackitAPIWithUpstreamMixin,

--- a/hardly/handlers/distgit.py
+++ b/hardly/handlers/distgit.py
@@ -21,6 +21,10 @@ from packit_service.worker.handlers import JobHandler
 from packit_service.worker.handlers.abstract import (
     reacts_to,
 )
+from packit_service.worker.mixin import (
+    ConfigFromEventMixin,
+    PackitAPIWithUpstreamMixin,
+)
 from packit_service.worker.reporting import StatusReporter, BaseCommitStatus
 from packit_service.worker.result import TaskResults
 
@@ -48,7 +52,11 @@ def fix_bz_refs(message: str) -> str:
 
 # @configured_as(job_type=JobType.dist_git_pr)  # Requires a change in packit
 @reacts_to(event=MergeRequestGitlabEvent)
-class DistGitMRHandler(JobHandler):
+class DistGitMRHandler(
+    JobHandler,
+    ConfigFromEventMixin,
+    PackitAPIWithUpstreamMixin,
+):
     task_name = TaskName.dist_git_pr
 
     def __init__(
@@ -78,7 +86,7 @@ class DistGitMRHandler(JobHandler):
         self._source_git_pr_model = None
         self._dist_git_pr_model = None
         self._dist_git_pr = None
-        self._packit = None
+        self._local_project: Optional[LocalProject] = None
 
     @property
     def source_git_pr_model(self) -> PullRequestModel:
@@ -110,26 +118,30 @@ class DistGitMRHandler(JobHandler):
         return self._dist_git_pr
 
     @property
-    def packit(self) -> PackitAPI:
-        if not self._packit:
+    def local_project(self) -> LocalProject:
+        if not self._local_project:
             source_project = self.service_config.get_project(
                 url=self.source_project_url
             )
-            local_project = LocalProject(
+            self._local_project = LocalProject(
                 git_project=source_project,
                 ref=self.data.commit_sha,
                 working_dir=self.service_config.command_handler_work_dir,
             )
             # We need to fetch tags from the upstream source-git repo
             # Details: https://github.com/packit/hardly/issues/61
-            local_project.fetch(self.project.get_web_url(), force=True)
+            self._local_project.fetch(self.project.get_web_url(), force=True)
+        return self._local_project
 
-            self._packit = PackitAPI(
+    @property
+    def packit_api(self):
+        if not self._packit_api:
+            self._packit_api = PackitAPI(
                 config=self.service_config,
                 package_config=self.package_config,
-                upstream_local_project=local_project,
+                upstream_local_project=self.local_project,
             )
-        return self._packit
+        return self._packit_api
 
     def sync_release(self) -> PullRequest:
         dg_mr_info = f"""###### Info for package maintainer
@@ -140,9 +152,9 @@ This MR has been automatically created from
 Please review the contribution and once you are comfortable with the content,
 you should trigger a CI pipeline run via `Pipelines → Run pipeline`."""
 
-        return self.packit.sync_release(
+        return self.packit_api.sync_release(
             dist_git_branch=self.target_repo_branch,
-            version=self.packit.up.get_specfile_version(),
+            version=self.packit_api.up.get_specfile_version(),
             add_new_sources=False,
             title=self.mr_title,
             description=f"{fix_bz_refs(self.mr_description)}\n\n---\n{dg_mr_info}",
@@ -224,7 +236,7 @@ you should trigger a CI pipeline run via `Pipelines → Run pipeline`."""
 
         if (
             self.target_repo_branch
-            not in self.packit.dg.local_project.git_project.get_branches()
+            not in self.packit_api.dg.local_project.git_project.get_branches()
         ):
             msg = (
                 "Can't create a dist-git pull/merge request out of this contribution "
@@ -278,7 +290,11 @@ We want to run checks there only so they don't need to be reimplemented in sourc
         return False
 
 
-class SyncFromDistGitPRHandler(JobHandler):
+class SyncFromDistGitPRHandler(
+    JobHandler,
+    ConfigFromEventMixin,
+    PackitAPIWithUpstreamMixin,
+):
     def __init__(
         self,
         package_config: PackageConfig,

--- a/hardly/jobs.py
+++ b/hardly/jobs.py
@@ -15,7 +15,7 @@ from packit_service.worker.events import (
     PipelineGitlabEvent,
 )
 from packit_service.worker.events.pagure import PullRequestFlagPagureEvent
-from packit_service.worker.handlers import JobHandler
+from packit_service.worker.handlers.abstract import JobHandler
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.parser import Parser
 from packit_service.worker.result import TaskResults

--- a/hardly/tasks.py
+++ b/hardly/tasks.py
@@ -6,9 +6,6 @@ from os import getenv
 from socket import gaierror
 from typing import List, Optional
 
-# Let a remote debugger (Visual Studio Code client)
-# access this running instance.
-import debugpy
 from celery import Task
 from celery.signals import after_setup_logger
 from syslog_rfc5424_formatter import RFC5424Formatter
@@ -29,15 +26,18 @@ from packit_service.constants import (
 from packit_service.utils import load_job_config, load_package_config
 from packit_service.worker.result import TaskResults
 
-# Allow other computers to attach to debugpy at this IP address and port.
-debugpy.listen(("0.0.0.0", 5678))
+# Let a remote debugger (Visual Studio Code client)
+# access this running instance.
+if getenv("DEBUGPY"):
+    import debugpy
 
-# Uncomment the following lines if you want to
-# pause the program until a remote debugger is attached
+    # Allow other computers to attach to debugpy at this IP address and port.
+    debugpy.listen(("0.0.0.0", 5678))
 
-# print("Waiting for debugger attach")
-# debugpy.wait_for_client()
-# debugpy.breakpoint()
+    # To pause the program until a remote debugger is attached
+    print("Waiting for debugger attach")
+    debugpy.wait_for_client()
+    debugpy.breakpoint()
 
 logger = logging.getLogger(__name__)
 

--- a/tests/data/webhooks/gitlab/mr_event.json
+++ b/tests/data/webhooks/gitlab/mr_event.json
@@ -92,11 +92,11 @@
       "http_url": "https://gitlab.com/packit-service/src/open-vm-tools.git"
     },
     "last_commit": {
-      "id": "6b7ede26456bb7fbcc3d1760d43f59a8f4ca7369",
+      "id": "82f9b8108e06a90e9cd0b43e8aafa6b991f981d9",
       "message": "Add check that the packet size received is >= expected packet header size.\n\nDnD RpcV3: A corrupted packet received may result in an OOB\nmemory access if the length of the message received is less than the size\nof the expected packet header.\n",
       "title": "Add check that the packet size received is >= expected packet header size.",
       "timestamp": "2021-08-02T10:33:26+02:00",
-      "url": "https://gitlab.com/packit-service/src/open-vm-tools/-/commit/6b7ede26456bb7fbcc3d1760d43f59a8f4ca7369",
+      "url": "https://gitlab.com/packit-service/src/open-vm-tools/-/commit/82f9b8108e06a90e9cd0b43e8aafa6b991f981d9",
       "author": {
         "name": "John Wolfe",
         "email": "jwolfe@vmware.com"

--- a/tests/integration/test_dist_git_mr.py
+++ b/tests/integration/test_dist_git_mr.py
@@ -106,6 +106,7 @@ def test_dist_git_mr(
     config = ServiceConfig()
     config.command_handler_work_dir = SANDCASTLE_WORK_DIR
     config.gitlab_mr_targets_handled = None
+    config.package_config_path_override = ".distro/source-git.yaml"
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(config)
     flexmock(Pushgateway).should_receive("push").once().and_return()
     flexmock(GitlabPullRequest).should_receive("comment").and_return()


### PR DESCRIPTION
Some properties moved from Handler to the Mixins with https://github.com/packit/packit-service/commit/bf1b977f37b6f21bb083983db42884034dbf9dd1

Fixes
`TypeError: Can't instantiate abstract class DistGitMRHandler with abstract methods clean_api, packit_api, project, project_url, service_config`

Plus a few more fixes.