### PR TITLE
Give the 'Sync from dist-git' PR a specific title

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
   - repo: https://github.com/asottile/pyupgrade
@@ -38,7 +38,7 @@ repos:
           - --max-line-length=100
           - --per-file-ignores=files/packit.wsgi:F401,E402
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1
+    rev: v1.2.0
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]

--- a/hardly/constants.py
+++ b/hardly/constants.py
@@ -3,3 +3,5 @@
 
 SOURCEGIT_URL = "https://gitlab.com/"
 SOURCEGIT_NAMESPACE = "src"
+
+DISTGIT_TO_SOURCEGIT_PR_TITLE = "Sync from dist-git"

--- a/hardly/handlers/distgit_to_sourcegitPR.py
+++ b/hardly/handlers/distgit_to_sourcegitPR.py
@@ -5,7 +5,11 @@ from logging import getLogger
 from os import getenv
 from typing import Optional
 
-from hardly.constants import SOURCEGIT_URL, SOURCEGIT_NAMESPACE
+from hardly.constants import (
+    DISTGIT_TO_SOURCEGIT_PR_TITLE,
+    SOURCEGIT_URL,
+    SOURCEGIT_NAMESPACE,
+)
 from hardly.handlers.abstract import TaskName, reacts_to
 from packit.api import PackitAPI
 from packit.config.job_config import JobConfig
@@ -122,6 +126,10 @@ class DistGitToSourceGitPRHandler(
             f"About to sync {self.dist_git_local_project.git_project}#{branch}"
             f" to {self.source_git_local_project.git_project}#{branch}"
         )
-        self.packit_api.sync_push(dist_git_branch=branch, source_git_branch=branch)
+        self.packit_api.sync_push(
+            dist_git_branch=branch,
+            source_git_branch=branch,
+            title=DISTGIT_TO_SOURCEGIT_PR_TITLE,
+        )
 
         return TaskResults(success=True)

--- a/hardly/handlers/sourcegitPR_to_distgitPR.py
+++ b/hardly/handlers/sourcegitPR_to_distgitPR.py
@@ -6,6 +6,7 @@ from logging import getLogger
 from os import getenv
 from typing import Optional
 
+from hardly.constants import DISTGIT_TO_SOURCEGIT_PR_TITLE
 from hardly.handlers.abstract import TaskName, reacts_to
 from ogr.abstract import PullRequest
 from packit.api import PackitAPI
@@ -213,6 +214,10 @@ you should trigger a CI pipeline run via `Pipelines → Run pipeline`."""
         If user creates a merge-request on the source-git repository,
         create a matching merge-request to the dist-git repository.
         """
+        if self.pr_title.startswith(DISTGIT_TO_SOURCEGIT_PR_TITLE):
+            logger.debug(f"{DISTGIT_TO_SOURCEGIT_PR_TITLE} PR opened by us.")
+            return TaskResults(success=True)
+
         if not self.handle_target():
             logger.debug(
                 "Not creating/updating a dist-git MR from "


### PR DESCRIPTION
so that we can check it in the `SourceGitPRToDistGitPRHandler` and not react (create a dist-git PR) to it if it was created by us.