### PR TITLE
Rename packages_config argument back to package_config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,8 +52,8 @@ services:
       - ../packit/packit:/usr/local/lib/python3.11/site-packages/packit:ro,z
       - ../packit-service/packit_service:/usr/local/lib/python3.11/site-packages/packit_service:ro,z
       - ./secrets/${SERVICE}/dev/packit-service.yaml:/home/packit/.config/packit-service.yaml:ro,z
-      - ./secrets/${SERVICE}/dev/id_rsa.pub:/packit-ssh/id_rsa.pub:ro,z
-      - ./secrets/${SERVICE}/dev/id_rsa:/packit-ssh/id_rsa:ro,z
+      - ./secrets/${SERVICE}/dev/id_ed25519.pub:/packit-ssh/id_ed25519.pub:ro,z
+      - ./secrets/${SERVICE}/dev/id_ed25519:/packit-ssh/id_ed25519:ro,z
     user: "1024"
 
   service:

--- a/hardly/tasks.py
+++ b/hardly/tasks.py
@@ -97,10 +97,10 @@ def hardly_process(self, event: dict) -> List[TaskResults]:
 
 @celery_app.task(name=TaskName.source_git_pr_to_dist_git_pr, base=HandlerTaskWithRetry)
 def run_source_git_pr_to_dist_git_pr_handler(
-    event: dict, packages_config: dict, job_config: dict
+    event: dict, package_config: dict, job_config: dict
 ):
     job_config_obj = load_job_config(job_config)
-    packages_config_obj = load_package_config(packages_config)
+    packages_config_obj = load_package_config(package_config)
     handler = SourceGitPRToDistGitPRHandler(
         package_config=packages_config_obj.get_package_config_for(job_config_obj),
         job_config=job_config_obj,
@@ -111,10 +111,10 @@ def run_source_git_pr_to_dist_git_pr_handler(
 
 @celery_app.task(name=TaskName.gitlab_ci_to_source_git_pr, base=HandlerTaskWithRetry)
 def run_gitlab_ci_to_source_git_pr_handler(
-    event: dict, packages_config: dict, job_config: dict
+    event: dict, package_config: dict, job_config: dict
 ):
     job_config_obj = load_job_config(job_config)
-    packages_config_obj = load_package_config(packages_config)
+    packages_config_obj = load_package_config(package_config)
     handler = GitlabCIToSourceGitPRHandler(
         package_config=packages_config_obj.get_package_config_for(job_config_obj),
         job_config=job_config_obj,
@@ -125,10 +125,10 @@ def run_gitlab_ci_to_source_git_pr_handler(
 
 @celery_app.task(name=TaskName.pagure_ci_to_source_git_pr, base=HandlerTaskWithRetry)
 def run_pagure_ci_to_source_git_pr_handler(
-    event: dict, packages_config: dict, job_config: dict
+    event: dict, package_config: dict, job_config: dict
 ):
     job_config_obj = load_job_config(job_config)
-    packages_config_obj = load_package_config(packages_config)
+    packages_config_obj = load_package_config(package_config)
     handler = PagureCIToSourceGitPRHandler(
         package_config=packages_config_obj.get_package_config_for(job_config_obj),
         job_config=job_config_obj,
@@ -139,10 +139,10 @@ def run_pagure_ci_to_source_git_pr_handler(
 
 @celery_app.task(name=TaskName.dist_git_to_source_git_pr, base=HandlerTaskWithRetry)
 def run_dist_git_to_source_git_pr_handler(
-    event: dict, packages_config: dict, job_config: dict
+    event: dict, package_config: dict, job_config: dict
 ):
     job_config_obj = load_job_config(job_config)
-    packages_config_obj = load_package_config(packages_config)
+    packages_config_obj = load_package_config(package_config)
     handler = DistGitToSourceGitPRHandler(
         package_config=packages_config_obj.get_package_config_for(job_config_obj),
         job_config=job_config_obj,

--- a/tests/integration/test_sourcegitPR_to_distgitPR.py
+++ b/tests/integration/test_sourcegitPR_to_distgitPR.py
@@ -141,7 +141,7 @@ This MR has been automatically created from
 
     event = Parser.parse_event(mr_event)
     results = run_source_git_pr_to_dist_git_pr_handler(
-        packages_config=dump_package_config(event.packages_config),
+        package_config=dump_package_config(event.packages_config),
         event=event.get_dict(),
         job_config=None,
     )


### PR DESCRIPTION
as that's what's in the [Celery task Signature](https://github.com/packit/packit-service/blob/63831f0a3a320498fd7037af1c83827a36c68c3f/packit_service/worker/handlers/abstract.py#L365)

Fixes https://red-hat-it.sentry.io/issues/4123962204