### PR TITLE
Add commit_sha attribute to GitlabCIToSourceGitPRHandler

### DIFF
--- a/hardly/handlers/distgitCI_to_sourcegitPR.py
+++ b/hardly/handlers/distgitCI_to_sourcegitPR.py
@@ -142,6 +142,7 @@ class GitlabCIToSourceGitPRHandler(DistGitCIToSourceGitPRHandler):
         )
         self.source: str = event["source"]
         self.merge_request_url: str = event["merge_request_url"]
+        self.commit_sha = event["commit_sha"]
 
     def dist_git_pr_model(self) -> Optional[PullRequestModel]:
         if self.source == "merge_request_event":


### PR DESCRIPTION
should probably have been added in 1c6ec16d

Fixes https://red-hat-it.sentry.io/issues/4395645599/?project=5820241